### PR TITLE
Add support for reading audio codecs

### DIFF
--- a/src/main/java/com/kyant/taglib/AudioProperties.kt
+++ b/src/main/java/com/kyant/taglib/AudioProperties.kt
@@ -13,4 +13,5 @@ public data class AudioProperties(
     val bitrate: Int,
     val sampleRate: Int,
     val channels: Int,
+    val codec: String
 )


### PR DESCRIPTION
Adds a new field in AudioProperties for the codec of the stream. There may be a cleaner way to do this, but I haven't found another way.